### PR TITLE
Use clearer inputs for action

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -19,7 +19,7 @@ jobs:
           fetch-depth: 0
       - uses: octue/check-semantic-version@main
         with:
-          version_source_type: pyproject.toml
+          path: pyproject.toml
 
   tests:
     if: "!contains(github.event.head_commit.message, 'skipci')"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,8 @@ jobs:
         uses: snok/install-poetry@v1
 
       - name: Get package version
-        run: echo "PACKAGE_VERSION=$(poetry version -s)" >> $GITHUB_ENV
+        id: get-package-version
+        run: echo "PACKAGE_VERSION=$(poetry version -s)" >> $GITHUB_OUTPUT
 
       - name: Install tox
         run: pip install tox
@@ -35,14 +36,13 @@ jobs:
         run: tox
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@v3
         with:
-          file: coverage.xml
+          files: coverage.xml
           fail_ci_if_error: false
-          token: ${{ secrets.CODECOV_TOKEN }}
 
     outputs:
-      package_version: ${{ env.PACKAGE_VERSION }}
+      package_version: ${{ steps.get-package-version.outputs.PACKAGE_VERSION }}
 
   release:
     runs-on: ubuntu-latest

--- a/.github/workflows/update-pull-request.yml
+++ b/.github/workflows/update-pull-request.yml
@@ -19,7 +19,8 @@ jobs:
     steps:
     - uses: actions/checkout@v3
 
-    - uses: octue/generate-pull-request-description@1.0.0.beta-0
+    - uses: octue/generate-pull-request-description@1.0.0.beta-2
+      id: pr-description
       with:
         pull_request_url: ${{ github.event.pull_request.url }}
         api_token: ${{ secrets.GITHUB_TOKEN }}
@@ -27,5 +28,5 @@ jobs:
     - name: Update pull request body
       uses: riskledger/update-pr-description@v2
       with:
-        body: ${{ env.PULL_REQUEST_DESCRIPTION }}
+        body: ${{ steps.pr-description.outputs.pull_request_description }}
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -47,7 +47,7 @@ repos:
           - '^release/(?P<major>0|[1-9]\d*)\.(?P<minor>0|[1-9]\d*)\.(?P<patch>0|[1-9]\d*)(?:-(?P<prerelease>(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+(?P<buildmetadata>[0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$'
 
   - repo: https://github.com/octue/conventional-commits
-    rev: 0.7.0
+    rev: 0.8.1
     hooks:
       - id: check-commit-message-is-conventional
         stages: [commit-msg]

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ RUN curl -L https://github.com/idc101/git-mkver/releases/download/v1.2.1/git-mkv
     | tar xvz \
     && mv git-mkver /usr/local/bin
 
-RUN pip3 install git+https://github.com/octue/check-semantic-version@1.0.0.beta-0
+RUN pip3 install git+https://github.com/octue/check-semantic-version@1.0.0.beta-2
 
 COPY check_semantic_version/entrypoint.sh /entrypoint.sh
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ steps:
     fetch-depth: 0
 - uses: octue/check-semantic-version@1.0.0.beta-2
   with:
-    version_source_type: setup.py
+    path: setup.py
 ```
 
 See [here](examples/workflow.yml) for an example in a workflow.

--- a/README.md
+++ b/README.md
@@ -4,14 +4,10 @@
 [![black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/ambv/black)
 
 # Semantic version checker
-A GitHub action that automatically checks if a package's semantic version is correct. It compares
-the semantic version specified in the given type of "version source" file against the expected semantic version
-calculated from the commits since the last tagged version in the git history. This is determined according to the
-mandatory `git-mkver` configuration file in the working directory. If the version source file and the expected version
-agree, the checker exits with a zero return code and displays a success message. If they don't agree, it exits with a
-non-zero return code and displays an error message.
+A GitHub action that automatically checks if a package's semantic version is correct based on the
+[Conventional Commit](https://www.conventionalcommits.org/en/) messages on the branch.
 
-The checker works with:
+It supports the following version source files:
 - `setup.py`
 - `pyproject.toml`
 - `package.json`
@@ -34,6 +30,13 @@ See [here](examples/workflow.yml) for an example in a workflow.
 
 ## More information
 
+### How does it work?
+The action compares the semantic version specified in the package's version source file (e.g. `setup.py`) against the
+expected semantic version calculated by `git-mkver` from the Conventional Commits created since the last tagged version
+in the branch's git history. This is determined according to the `mkver.conf` file in the working directory. If the
+version source file and the expected version agree, the checker exits with a zero return code and displays a success
+message. If they don't agree, it exits with a non-zero return code and displays an error message.
+
 ### Example
 For [this standard configuration file](examples/mkver.conf), if the last tagged version in your
 repository is `0.7.3` and since then:
@@ -45,7 +48,7 @@ repository is `0.7.3` and since then:
 
 ### Version source files
 A version source file is one of the following, which must contain the package version:
-* `setup.py` (this covers versions defined in a `setup.py` or `setup.cfg` file)
+* `setup.py`
 * `pyproject.toml`
 * `package.json`
 
@@ -53,6 +56,6 @@ If the version source file is not in the root directory, an optional argument ca
 look at a file of the version source file type at a different location.
 
 ### `mkver.conf` files
-Note that this command requires a `mkver.conf` file to be present in the working directory (usually the repository root):
+Note that this action requires a `mkver.conf` file to be present in the working directory (usually the repository root):
 - [See an example for non-beta packages](examples/mkver.conf) (full semantic versioning)
 - [See an example for packages in beta](examples/mkver-for-beta-versions.conf) (keeps the version below `1.0.0`)

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/ambv/black)
 
 # Semantic version checker
-A GitHub action and command-line tool that automatically checks if a package's semantic version is correct. It compares
+A GitHub action that automatically checks if a package's semantic version is correct. It compares
 the semantic version specified in the given type of "version source" file against the expected semantic version
 calculated from the commits since the last tagged version in the git history. This is determined according to the
 mandatory `git-mkver` configuration file in the working directory. If the version source file and the expected version
@@ -16,8 +16,8 @@ The checker works with:
 - `pyproject.toml`
 - `package.json`
 
-## GitHub action
-The checker can be easily used as a step in a GitHub workflow:
+## Usage
+Add a `mkver.conf` file to your repository and add the action as a step in your workflow:
 
 ```yaml
 steps:
@@ -25,26 +25,12 @@ steps:
   with:
     # Set fetch-depth to 0 to fetch all tags (necessary for git-mkver to determine the correct semantic version).
     fetch-depth: 0
-- uses: octue/check-semantic-version@1.0.0.beta-0
+- uses: octue/check-semantic-version@1.0.0.beta-2
   with:
     version_source_type: setup.py
 ```
 
 See [here](examples/workflow.yml) for an example in a workflow.
-
-## CLI
-```shell
-usage: check-semantic-version [-h] [--file FILE] {setup.py,pyproject.toml,package.json}
-
-positional arguments:
-  {setup.py,pyproject.toml,package.json}
-                        The type of file to look for the version in. It must be one of ['setup.py', 'pyproject.toml', 'package.json'] and is assumed to be in the
-                        repository root unless the --file option is also given
-
-optional arguments:
-  -h, --help            show this help message and exit
-  --file FILE           The path to the version source file if it isn't in the repository root e.g. path/to/setup.py
-```
 
 ## More information
 
@@ -66,9 +52,7 @@ A version source file is one of the following, which must contain the package ve
 If the version source file is not in the root directory, an optional argument can be passed to the checker to tell it to
 look at a file of the version source file type at a different location.
 
-### Extra requirements
-Note that this command requires:
-* `git-mkver` to be installed and available in the shell as `git-mkver` (this is already done if using the GitHub action)
-* A `mkver.conf` file to be present in the working directory (usually the repository root):
-  - [See an example for non-beta packages](examples/mkver.conf) (full semantic versioning)
-  - [See an example for packages in beta](examples/mkver-for-beta-versions.conf) (keeps the version below `1.0.0`)
+### `mkver.conf` files
+Note that this command requires a `mkver.conf` file to be present in the working directory (usually the repository root):
+- [See an example for non-beta packages](examples/mkver.conf) (full semantic versioning)
+- [See an example for packages in beta](examples/mkver-for-beta-versions.conf) (keeps the version below `1.0.0`)

--- a/action.yaml
+++ b/action.yaml
@@ -1,17 +1,15 @@
 name: 'Check semantic version'
-description: 'Check that the version of your package is the same as the expected semantic version calculated from the conventional commits on your current branch.'
+description: 'Check the version of your package is the same as the semantic version calculated from the conventional commits on the branch.'
 author: 'Marcus Lugg'
+branding:
+  icon: git-commit
+  color: green
 inputs:
-  version_source_type:
-    description: 'The name of the type of file containing the current version number (one of "setup.py", "pyproject.toml", or "package.json")'
+  path:
+    description: 'The path of the file containing the current version number (must be one of "setup.py", "pyproject.toml", or "package.json").'
     required: true
-  version_source_path:
-    description: 'The path to the version source file if it is not in the repository root.'
-    required: false
-    default: ''
 runs:
    using: 'docker'
    image: 'docker://octue/check-semantic-version:1.0.0.beta-2'
    args:
-     - ${{ inputs.version_source_type }}
-     - ${{ inputs.version_source_path }}
+     - ${{ inputs.path }}

--- a/action.yaml
+++ b/action.yaml
@@ -11,7 +11,7 @@ inputs:
     default: ''
 runs:
    using: 'docker'
-   image: 'docker://octue/check-semantic-version:1.0.0.beta-0'
+   image: 'docker://octue/check-semantic-version:1.0.0.beta-2'
    args:
      - ${{ inputs.version_source_type }}
      - ${{ inputs.version_source_path }}

--- a/action.yaml
+++ b/action.yaml
@@ -1,5 +1,5 @@
 name: 'Check semantic version'
-description: 'Check the version of your package is the same as the semantic version calculated from the conventional commits on the branch.'
+description: 'Check the version of your package is the same as the semantic version calculated from the Conventional Commits on the branch.'
 author: 'Marcus Lugg'
 branding:
   icon: git-commit

--- a/check_semantic_version/entrypoint.sh
+++ b/check_semantic_version/entrypoint.sh
@@ -1,4 +1,4 @@
 #!/bin/sh -l
 
 cd $GITHUB_WORKSPACE
-check-semantic-version $1 $2
+check-semantic-version $1

--- a/examples/workflow.yml
+++ b/examples/workflow.yml
@@ -11,6 +11,6 @@ jobs:
         with:
           # Set fetch-depth to 0 to fetch all tags (necessary for git-mkver to determine the correct semantic version).
           fetch-depth: 0
-      - uses: octue/check-semantic-version@1.0.0.beta-0
+      - uses: octue/check-semantic-version@1.0.0.beta-2
         with:
-          version_source_type: setup.py
+          path: setup.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "check-semantic-version"
-version = "1.0.0.beta-1"
+version = "1.0.0.beta-2"
 description = "A GitHub action that checks the version of your package is the same as the expected semantic version calculated from the conventional commits on your current branch."
 authors = ["Marcus Lugg <marcus@octue.com>"]
 readme = "README.md"

--- a/tests/test_check_semantic_version.py
+++ b/tests/test_check_semantic_version.py
@@ -24,7 +24,7 @@ class TestCheckSemanticVersion(unittest.TestCase):
     def test_error_raised_if_unsupported_version_source_provided(self):
         """Ensure an error is raised if an unsupported version source is provided."""
         with self.assertRaises(ValueError):
-            check_semantic_version.get_current_version(version_source="blah")
+            check_semantic_version.get_current_version(path="blah")
 
     def test_get_current_version_for_setup_py(self):
         try:
@@ -36,10 +36,7 @@ class TestCheckSemanticVersion(unittest.TestCase):
 
     def test_get_current_version_with_custom_file_path_for_setup_py(self):
         """Test that the current version can be extracted from a different file than the top-level setup.py file."""
-        version = check_semantic_version.get_current_version(
-            "setup.py", version_source_file=os.path.join(TEST_DATA_DIRECTORY, "setup.py")
-        )
-
+        version = check_semantic_version.get_current_version(path=os.path.join(TEST_DATA_DIRECTORY, "setup.py"))
         self.assertEqual(version, "0.3.4")
 
     def test_get_current_version_for_pyproject_toml(self):
@@ -52,10 +49,7 @@ class TestCheckSemanticVersion(unittest.TestCase):
 
     def test_get_current_version_with_custom_file_path_for_pyproject_toml(self):
         """Test that the current version can be extracted from a different file than the top-level file pyproject.toml."""
-        version = check_semantic_version.get_current_version(
-            "pyproject.toml", version_source_file=os.path.join(TEST_DATA_DIRECTORY, "pyproject.toml")
-        )
-
+        version = check_semantic_version.get_current_version(path=os.path.join(TEST_DATA_DIRECTORY, "pyproject.toml"))
         self.assertEqual(version, "0.6.3")
 
     def test_get_current_version_for_package_json(self):
@@ -68,10 +62,7 @@ class TestCheckSemanticVersion(unittest.TestCase):
 
     def test_get_current_version_with_custom_file_path_for_package_json(self):
         """Test that the current version can be extracted from a different file than the top-level package.json file."""
-        version = check_semantic_version.get_current_version(
-            "package.json", version_source_file=os.path.join(TEST_DATA_DIRECTORY, "package.json")
-        )
-
+        version = check_semantic_version.get_current_version(path=os.path.join(TEST_DATA_DIRECTORY, "package.json"))
         self.assertEqual(version, "1.5.3")
 
     def test_get_expected_semantic_version(self):


### PR DESCRIPTION
<!--- SKIP AUTOGENERATED NOTES --->
# Contents ([#6](https://github.com/octue/check-semantic-version/pull/6))

**IMPORTANT:** There is 1 breaking change.

### Enhancements
- 💥 **BREAKING CHANGE:** Combine action inputs into one

### Operations
- Improve workflows

### Other
- Improve README

---
# Upgrade instructions
<details>
<summary>💥 <b>Combine action inputs into one</b></summary>

Replace the `version_source_type` and `version_source_path` inputs with the new `path` input, giving its value as the path to the file containing your package's version information.
</details>

<!--- END AUTOGENERATED NOTES --->