### PR TITLE
Install `jq` in docker image

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -17,7 +17,7 @@ jobs:
         with:
           # Set fetch-depth to 0 to fetch all tags (necessary for git-mkver to determine the correct semantic version).
           fetch-depth: 0
-      - uses: octue/check-semantic-version@1.0.0.beta-7
+      - uses: octue/check-semantic-version@1.0.0.beta-8
         with:
           path: pyproject.toml
           breaking_change_indicated_by: major

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.10.7-slim
 
-RUN apt-get update && apt-get install -y --no-install-recommends curl git && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y --no-install-recommends curl git jq && rm -rf /var/lib/apt/lists/*
 
 RUN curl -L https://github.com/idc101/git-mkver/releases/download/v1.2.1/git-mkver-linux-amd64-1.2.1.tar.gz \
     | tar xvz \

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ RUN curl -L https://github.com/idc101/git-mkver/releases/download/v1.2.1/git-mkv
     | tar xvz \
     && mv git-mkver /usr/local/bin
 
-RUN pip3 install git+https://github.com/octue/check-semantic-version@1.0.0.beta-7
+RUN pip3 install git+https://github.com/octue/check-semantic-version@1.0.0.beta-8
 
 COPY check_semantic_version/entrypoint.sh /entrypoint.sh
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ steps:
   with:
     # Set fetch-depth to 0 to fetch all tags (necessary for `git-mkver` to determine the correct semantic version).
     fetch-depth: 0
-- uses: octue/check-semantic-version@1.0.0.beta-7
+- uses: octue/check-semantic-version@1.0.0.beta-8
   with:
     path: setup.py
     breaking_change_indicated_by: major

--- a/action.yaml
+++ b/action.yaml
@@ -14,7 +14,7 @@ inputs:
     default: 'major'
 runs:
    using: 'docker'
-   image: 'docker://octue/check-semantic-version:1.0.0.beta-7'
+   image: 'docker://octue/check-semantic-version:1.0.0.beta-8'
    args:
      - ${{ inputs.path }}
      - ${{ inputs.breaking_change_indicated_by }}

--- a/check_semantic_version/cli.py
+++ b/check_semantic_version/cli.py
@@ -14,7 +14,6 @@ def main(argv=None):
 
     parser.add_argument(
         "path",
-        choices=SUPPORTED_VERSION_SOURCE_FILES,
         help=f"The path to the version source file. The file must be one of these types: {SUPPORTED_VERSION_SOURCE_FILES}",
     )
 

--- a/examples/workflow.yml
+++ b/examples/workflow.yml
@@ -11,6 +11,6 @@ jobs:
         with:
           # Set fetch-depth to 0 to fetch all tags (necessary for git-mkver to determine the correct semantic version).
           fetch-depth: 0
-      - uses: octue/check-semantic-version@1.0.0.beta-7
+      - uses: octue/check-semantic-version@1.0.0.beta-8
         with:
           path: setup.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "check-semantic-version"
-version = "1.0.0.beta-7"
+version = "1.0.0.beta-8"
 description = "A GitHub action that checks the version of your package is the same as the expected semantic version calculated from the conventional commits on your current branch."
 authors = ["Marcus Lugg <marcus@octue.com>"]
 readme = "README.md"


### PR DESCRIPTION
# Summary
Fix a bug where `package.json` files couldn't be parsed due to a missing `jq` installation in the docker image.

<!--- SKIP AUTOGENERATED NOTES --->
# Contents ([#12](https://github.com/octue/check-semantic-version/pull/12))

### Fixes
- Install `jq` in docker image
- Allow full paths to be passed in via CLI

<!--- END AUTOGENERATED NOTES --->