### PR TITLE
Add missing return statement

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -17,7 +17,7 @@ jobs:
         with:
           # Set fetch-depth to 0 to fetch all tags (necessary for git-mkver to determine the correct semantic version).
           fetch-depth: 0
-      - uses: octue/check-semantic-version@1.0.0.beta-9
+      - uses: octue/check-semantic-version@main
         with:
           path: pyproject.toml
           breaking_change_indicated_by: major

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -17,7 +17,7 @@ jobs:
         with:
           # Set fetch-depth to 0 to fetch all tags (necessary for git-mkver to determine the correct semantic version).
           fetch-depth: 0
-      - uses: octue/check-semantic-version@1.0.0.beta-8
+      - uses: octue/check-semantic-version@1.0.0.beta-9
         with:
           path: pyproject.toml
           breaking_change_indicated_by: major

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ RUN curl -L https://github.com/idc101/git-mkver/releases/download/v1.2.1/git-mkv
     | tar xvz \
     && mv git-mkver /usr/local/bin
 
-RUN pip3 install git+https://github.com/octue/check-semantic-version@1.0.0.beta-8
+RUN pip3 install git+https://github.com/octue/check-semantic-version@1.0.0.beta-9
 
 COPY check_semantic_version/entrypoint.sh /entrypoint.sh
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ steps:
   with:
     # Set fetch-depth to 0 to fetch all tags (necessary for `git-mkver` to determine the correct semantic version).
     fetch-depth: 0
-- uses: octue/check-semantic-version@1.0.0.beta-8
+- uses: octue/check-semantic-version@1.0.0.beta-9
   with:
     path: setup.py
     breaking_change_indicated_by: major

--- a/action.yaml
+++ b/action.yaml
@@ -14,7 +14,7 @@ inputs:
     default: 'major'
 runs:
    using: 'docker'
-   image: 'docker://octue/check-semantic-version:1.0.0.beta-8'
+   image: 'docker://octue/check-semantic-version:1.0.0.beta-9'
    args:
      - ${{ inputs.path }}
      - ${{ inputs.breaking_change_indicated_by }}

--- a/check_semantic_version/check_semantic_version.py
+++ b/check_semantic_version/check_semantic_version.py
@@ -74,6 +74,7 @@ def check_versions_match(path, breaking_change_indicated_by="major"):
         f"{GREEN}VERSION PASSED CHECKS:{NO_COLOUR} The current version is the same as the expected semantic version: "
         f"{expected_semantic_version}."
     )
+    return True
 
 
 def _get_current_version(path, version_source_type):

--- a/examples/workflow.yml
+++ b/examples/workflow.yml
@@ -11,6 +11,6 @@ jobs:
         with:
           # Set fetch-depth to 0 to fetch all tags (necessary for git-mkver to determine the correct semantic version).
           fetch-depth: 0
-      - uses: octue/check-semantic-version@1.0.0.beta-8
+      - uses: octue/check-semantic-version@1.0.0.beta-9
         with:
           path: setup.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "check-semantic-version"
-version = "1.0.0.beta-8"
+version = "1.0.0.beta-9"
 description = "A GitHub action that checks the version of your package is the same as the expected semantic version calculated from the conventional commits on your current branch."
 authors = ["Marcus Lugg <marcus@octue.com>"]
 readme = "README.md"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -23,8 +23,8 @@ class TestCLI(unittest.TestCase):
                     with self.assertRaises(SystemExit) as e:
                         cli.main(["setup.py"])
 
-                        # Check that the exit code is 0.
-                        self.assertFalse(hasattr(e, "exception"))
+                    # Check that the exit code is 0.
+                    self.assertEqual(e.exception.code, 0)
 
                     message = mock_stdout.method_calls[0].args[0]
                     self.assertIn("VERSION PASSED CHECKS:", message)
@@ -43,8 +43,8 @@ class TestCLI(unittest.TestCase):
                     with self.assertRaises(SystemExit) as e:
                         cli.main(["setup.py"])
 
-                        # Check that the exit code is 1.
-                        self.assertEqual(e.exception.code, 1)
+                    # Check that the exit code is 1.
+                    self.assertEqual(e.exception.code, 1)
 
                     message = mock_stdout.method_calls[0].args[0]
                     self.assertIn("VERSION FAILED CHECKS:", message)
@@ -66,8 +66,8 @@ class TestCLI(unittest.TestCase):
                     with self.assertRaises(SystemExit) as e:
                         cli.main(["setup.py"])
 
-                        # Check that the exit code is 1.
-                        self.assertEqual(e.exception.code, 1)
+                    # Check that the exit code is 1.
+                    self.assertEqual(e.exception.code, 1)
 
                     message = mock_stdout.method_calls[0].args[0]
                     self.assertIn("VERSION FAILED CHECKS:", message)


### PR DESCRIPTION
<!--- START AUTOGENERATED NOTES --->
# Contents ([#13](https://github.com/octue/check-semantic-version/pull/13))

### Fixes
- Add missing return statement

### Operations
- Use action version available on `main` in CI

### Testing
- Fix CLI tests so exit code checks are carried out

<!--- END AUTOGENERATED NOTES --->