### PR TITLE
Fix release process for stable releases

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ RUN curl -L https://github.com/idc101/git-mkver/releases/download/v1.2.1/git-mkv
     | tar xvz \
     && mv git-mkver /usr/local/bin
 
-RUN pip3 install git+https://github.com/octue/check-semantic-version@1.0.0.beta-9
+RUN pip3 install git+https://github.com/octue/check-semantic-version@1.0.1
 
 COPY check_semantic_version/entrypoint.sh /entrypoint.sh
 

--- a/README.md
+++ b/README.md
@@ -4,27 +4,30 @@
 [![black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/ambv/black)
 
 # Semantic version checker
+
 A GitHub action that automatically checks if a package's semantic version is correct based on the
 [Conventional Commit](https://www.conventionalcommits.org/en/) messages on the branch.
 
 It supports the following version source files:
+
 - `setup.py`
 - `pyproject.toml`
 - `package.json`
 
 ## Usage
+
 Add the action as a step in your workflow:
 
 ```yaml
 steps:
-- uses: actions/checkout@v3
-  with:
-    # Set fetch-depth to 0 to fetch all tags (necessary for `git-mkver` to determine the correct semantic version).
-    fetch-depth: 0
-- uses: octue/check-semantic-version@1.0.0.beta-9
-  with:
-    path: setup.py
-    breaking_change_indicated_by: major
+  - uses: actions/checkout@v3
+    with:
+      # Set fetch-depth to 0 to fetch all tags (necessary for `git-mkver` to determine the correct semantic version).
+      fetch-depth: 0
+  - uses: octue/check-semantic-version@1.0.1
+    with:
+      path: setup.py
+      breaking_change_indicated_by: major
 ```
 
 See [here](examples/workflow.yml) for an example in a workflow.
@@ -32,6 +35,7 @@ See [here](examples/workflow.yml) for an example in a workflow.
 ## More information
 
 ### How does it work?
+
 The action compares the semantic version specified in the package's version source file (e.g. `setup.py`) against the
 expected semantic version calculated by `git-mkver` from the Conventional Commits created since the last tagged version
 in the branch's git history. If the version source file and the expected version agree, the checker exits with a zero
@@ -39,25 +43,31 @@ return code and displays a success message. If they don't agree, it exits with a
 error message.
 
 ### Version source files
+
 A version source file is one of the following, which must contain the package version:
-* `setup.py`
-* `pyproject.toml`
-* `package.json`
+
+- `setup.py`
+- `pyproject.toml`
+- `package.json`
 
 If the version source file is not in the root directory, an optional argument can be passed to the checker to tell it to
 look at a file of the version source file type at a different location.
 
 ### `mkver.conf` files
+
 This action automatically generates a standard `mkver.conf` file to configure `git-mkver`. For more control, you can add
 your own `mkver.conf` file to the repository root. Here are some example `mkver.conf` files:
+
 - [Non-beta packages](examples/mkver.conf) (full semantic versioning)
 - [Beta packages](examples/mkver-for-beta-versions.conf) (keeps the version below `1.0.0`)
 
 ### Example
+
 For [this standard configuration file](examples/mkver.conf), if the last tagged version in your
 repository is `0.7.3` and since then:
-* There has been a breaking change and any number of features or bug-fixes/small-changes, the expected version will
+
+- There has been a breaking change and any number of features or bug-fixes/small-changes, the expected version will
   be `1.0.0`
-* There has been a new feature, any number of bug-fixes/small-changes, but no breaking changes, the expected
+- There has been a new feature, any number of bug-fixes/small-changes, but no breaking changes, the expected
   version will be `0.8.0`
-* There has been a bug-fix/small-change but no breaking changes or new features, the expected version will be `0.7.4`
+- There has been a bug-fix/small-change but no breaking changes or new features, the expected version will be `0.7.4`

--- a/action.yaml
+++ b/action.yaml
@@ -14,7 +14,7 @@ inputs:
     default: 'major'
 runs:
    using: 'docker'
-   image: 'docker://octue/check-semantic-version:1.0.0.beta-9'
+   image: 'docker://octue/check-semantic-version:1.0.1'
    args:
      - ${{ inputs.path }}
      - ${{ inputs.breaking_change_indicated_by }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "check-semantic-version"
-version = "1.0.0"
+version = "1.0.1"
 description = "A GitHub action that checks the version of your package is the same as the expected semantic version calculated from the conventional commits on your current branch."
 authors = ["Marcus Lugg <marcus@octue.com>"]
 readme = "README.md"


### PR DESCRIPTION
<!-- PRs into main are released as soon as they are merged. Their descriptions will be used directly to create release notes, so make sure they contain everything! -->
<!-- Anything added between the auto-generation marker comments will be replaced on every pushed commit, so make sure to add anything you want to add outside of them. -->
<!-- However, any part of the final PR description (i.e. the description at the point of the final commit to the PR) can be changed in release notes after release if required -->
<!-- Change "START" to "SKIP" in the autogeneration marker to stop any further automatic changes to the description. ---> 

<!--- START AUTOGENERATED NOTES --->
# Contents ([#17](https://github.com/octue/check-semantic-version/pull/17))

### Operations
- Fix release process for stable releases

<!--- END AUTOGENERATED NOTES --->